### PR TITLE
Model io

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,28 +1,27 @@
 from __future__ import print_function
 from redisai import Client, Tensor, ScalarTensor, \
     BlobTensor, DType, Device, Backend
+from redisai import model as raimodel
 
 client = Client()
 client.tensorset('x', Tensor(DType.float, [2], [2, 3]))
 t = client.tensorget('x')
 print(t.value)
 
-MODEL_PATH = '../RedisAI/examples/models/graph.pb'
-
+model = raimodel.Model.load('../RedisAI/examples/models/graph.pb')
 client.tensorset('a', ScalarTensor(DType.float, 2, 3))
 client.tensorset('b', ScalarTensor(DType.float, 12, 10))
 client.modelset('m', Backend.tf,
                 Device.cpu,
                 input=['a', 'b'],
                 output='mul',
-                data=open(MODEL_PATH, 'rb').read())
+                data=model)
 client.modelrun('m', ['a', 'b'], ['mul'])
 print(client.tensorget('mul').value)
 
 # Try with a script
-SCRIPTPATH = '../RedisAI/examples/models/script.txt'
-
-client.scriptset('ket', Device.cpu, open(SCRIPTPATH, 'rb').read())
+script = raimodel.Model.load('../RedisAI/examples/models/script.txt')
+client.scriptset('ket', Device.cpu, script)
 client.scriptrun('ket', 'bar', input=['a', 'b'], output='c')
 
 b1 = client.tensorget('c', astype=BlobTensor)

--- a/redisai/__init__.py
+++ b/redisai/__init__.py
@@ -1,1 +1,2 @@
 from .client import (Client, Tensor, BlobTensor, DType, Device, Backend)
+from .model import Model

--- a/redisai/__init__.py
+++ b/redisai/__init__.py
@@ -1,2 +1,1 @@
 from .client import (Client, Tensor, BlobTensor, DType, Device, Backend)
-from .model import Model

--- a/redisai/model.py
+++ b/redisai/model.py
@@ -1,0 +1,83 @@
+import pickle
+
+from .client import Device, Backend
+# TODO: Move this imports inside functions if it affects performance
+try:
+    import tensorflow as tf
+except ModuleNotFoundError:
+    pass  # that's Okey if you don't have TF
+
+try:
+    import torch
+except ModuleNotFoundError:
+    pass  # it's Okey if you don't have PT either
+
+
+
+class Model:
+    
+    def __init__(self, path, device=Device.cpu, inputs=[], outputs=[]):
+        pass
+
+    @classmethod
+    def save(cls, obj, path, output_names=[], is_native=False):
+        # TODO: perhpas make output_names optional
+        # TODO: what if user doens't save as .pb/.pt and if we are relying on format
+        # TODO: check directory file exist etc
+        # TODO: accept filepath or file like object
+        if issubclass(type(obj), tf.Session):
+            # todo: do the checks
+            cls._save_tf_graph(obj, path, output_names, is_native)
+        elif issubclass(type(type(obj)), torch.jit.ScriptMeta):
+            # TODO make a proper check above
+            cls._save_pt_graph(obj, path, is_native)
+        else:
+            # TODO proper error message
+            raise TypeError('Invalid Object. Need PyTorch/Tensorflow graphs')
+
+    @classmethod
+    def _save_tf_graph(cls, sess, path, output_names, is_native):
+        graph_def = sess.graph_def
+        # clearing device information
+        for node in graph_def.node:
+            node.device = ""
+        frozen = tf.graph_util.convert_variables_to_constants(
+            sess, graph_def, output_names)
+        # TODO: configure the log dire - second param
+        if is_native:
+            tf.io.write_graph(frozen, '.', path, as_text=False)
+            return
+        outdict = cls._get_filled_dict(
+            frozen.SerializeToString(),
+            Backend.tf, output_names=output_names)
+        cls._write_custom_model(outdict, path)
+
+    @classmethod
+    def _save_pt_graph(cls, graph, path, is_native):
+        # todo check if we need to clear device for pytorch
+        # todo do `eval()`
+        if is_native:
+            torch.jit.save(graph, path)
+            return
+        outdict = cls._get_filled_dict(
+            graph.save_to_buffer(), Backend.torch)
+        cls._write_custom_model(outdict, path)
+
+    @staticmethod
+    def _get_filled_dict(graph, backend, input_names=[], output_names=[]):
+        # todo : better way to convert arguments to dict
+        return {
+            'graph': graph,
+            'backend': backend,
+            'input_names': input_names,
+            'output_names': output_names}
+
+    @staticmethod
+    def _write_custom_model(outdict, path):
+        with open(path, 'wb') as file:
+            pickle.dump(outdict, file)
+
+    @classmethod
+    def load(cls, path):
+        pass
+

--- a/redisai/model.py
+++ b/redisai/model.py
@@ -20,7 +20,7 @@ class Model:
 
     __slots__ = ['graph', 'backend', 'device', 'inputs', 'outputs']
     
-    def __init__(self, path, device=Device.cpu, inputs=[], outputs=[]):
+    def __init__(self, path, device=Device.cpu, inputs=None, outputs=None):
         """
         Declare a model suitable for passing to modelset
         :param path: Filepath from where the stored model can be read
@@ -37,7 +37,7 @@ class Model:
         raise NotImplementedError('Instance creation is not impelemented yet')
 
     @classmethod
-    def save(cls, obj, path: str, input=[], output=[], as_native=True):
+    def save(cls, obj, path: str, input=None, output=None, as_native=True):
         """
         Infer the backend (TF/PyTorch) by inspecting the class hierarchy
         and calls the appropriate serialization utility. It is essentially a
@@ -94,7 +94,7 @@ class Model:
             raise NotImplementedError('Saving non-native graph is not supported yet')
 
     @staticmethod
-    def _get_filled_dict(graph, backend, input=[], output=[]):
+    def _get_filled_dict(graph, backend, input=None, output=None):
         return {
             'graph': graph,
             'backend': backend,

--- a/redisai/model.py
+++ b/redisai/model.py
@@ -1,76 +1,105 @@
 import pickle
+import os
+import warnings
 
 from .client import Device, Backend
-# TODO: Move this imports inside functions if it affects performance
+
 try:
     import tensorflow as tf
-except ModuleNotFoundError:
+except (ModuleNotFoundError, ImportError):
     pass  # that's Okey if you don't have TF
 
 try:
     import torch
-except ModuleNotFoundError:
+except (ModuleNotFoundError, ImportError):
     pass  # it's Okey if you don't have PT either
 
 
 
 class Model:
+
+    __slots__ = ['graph', 'backend', 'device', 'inputs', 'outputs']
     
     def __init__(self, path, device=Device.cpu, inputs=[], outputs=[]):
-        pass
+        """
+        Declare a model suitable for passing to modelset
+        :param path: Filepath from where the stored model can be read
+        :param device: Enum from `redisai.Device` represents which device
+            should the model run on, inside RedisAI
+        :param inputs: Optional parameter required only for tensorflow.
+            In the TF world, this represents the list which is being
+            passed to `sess.run` with tensors which is required for
+            TF to execute the model
+        :param outputs: Optional parameter required only for tensorflow.
+            Similr to `inputs`, `outputs` is also passed to `sess.run` but
+            to fetch the output from
+        """
+        raise NotImplementedError('Instance creation is not impelemented yet')
 
     @classmethod
-    def save(cls, obj, path, output_names=[], is_native=False):
-        # TODO: perhpas make output_names optional
-        # TODO: what if user doens't save as .pb/.pt and if we are relying on format
-        # TODO: check directory file exist etc
-        # TODO: accept filepath or file like object
+    def save(cls, obj, path: str, input=[], output=[], as_native=True):
+        """
+        Infer the backend (TF/PyTorch) by inspecting the class hierarchy
+        and calls the appropriate serialization utility. It is essentially a
+        wrapper over serialization mechanism of each backend
+        :param path: Path to which the graph/model will be saved
+        :param input: Optional parameter required only for tensorflow.
+            In the TF world, this represents the list which is being
+            passed to `sess.run` with tensors which is required for
+            TF to execute the model
+        :param output: Optional parameter required only for tensorflow.
+            Similr to `input`, `output` is also passed to `sess.run` but
+            to fetch the output from
+        :param as_native: Saves the graph/model with backend's serialization
+            mechanism if True. If False, custom saving utility will be called
+            which saves other informations required for modelset. Defaults to True
+        """
         if issubclass(type(obj), tf.Session):
-            # todo: do the checks
-            cls._save_tf_graph(obj, path, output_names, is_native)
+            cls._save_tf_graph(obj, path, output, as_native)
         elif issubclass(type(type(obj)), torch.jit.ScriptMeta):
-            # TODO make a proper check above
-            cls._save_pt_graph(obj, path, is_native)
+            # TODO Is there a better way to check this
+            cls._save_pt_graph(obj, path, as_native)
         else:
-            # TODO proper error message
-            raise TypeError('Invalid Object. Need PyTorch/Tensorflow graphs')
+            raise TypeError(('Invalid Object. '
+                'Need traced graph or scripted graph from PyTorch or '
+                'Session object from Tensorflow'))
 
     @classmethod
-    def _save_tf_graph(cls, sess, path, output_names, is_native):
+    def _save_tf_graph(cls, sess, path, output, as_native):
         graph_def = sess.graph_def
         # clearing device information
         for node in graph_def.node:
             node.device = ""
         frozen = tf.graph_util.convert_variables_to_constants(
-            sess, graph_def, output_names)
-        # TODO: configure the log dire - second param
-        if is_native:
-            tf.io.write_graph(frozen, '.', path, as_text=False)
+            sess, graph_def, output)
+        if as_native:
+            directory = os.path.dirname(path)
+            file = os.path.basename(path)
+            tf.io.write_graph(frozen, directory, file, as_text=False)
             return
-        outdict = cls._get_filled_dict(
-            frozen.SerializeToString(),
-            Backend.tf, output_names=output_names)
-        cls._write_custom_model(outdict, path)
+        else:
+            raise NotImplementedError('Saving non-native graph is not supported yet')
 
     @classmethod
-    def _save_pt_graph(cls, graph, path, is_native):
-        # todo check if we need to clear device for pytorch
-        # todo do `eval()`
-        if is_native:
+    def _save_pt_graph(cls, graph, path, as_native):
+        # TODO how to handle the cpu/gpu
+        if as_native:
+            if graph.training == True:
+                warnings.warn(
+                    'Graph is in training mode. Converting to evaluation mode')
+                graph.eval()
             torch.jit.save(graph, path)
             return
-        outdict = cls._get_filled_dict(
-            graph.save_to_buffer(), Backend.torch)
-        cls._write_custom_model(outdict, path)
+        else:
+            raise NotImplementedError('Saving non-native graph is not supported yet')
 
     @staticmethod
-    def _get_filled_dict(graph, backend, input_names=[], output_names=[]):
-        # todo : better way to convert arguments to dict
+    def _get_filled_dict(graph, backend, input=[], output=[]):
         return {
             'graph': graph,
             'backend': backend,
-            'input_names': input_names,
-            'output_names': output_names}
+            'input': input,
+            'output': output}
 
     @staticmethod
     def _write_custom_model(outdict, path):
@@ -78,6 +107,12 @@ class Model:
             pickle.dump(outdict, file)
 
     @classmethod
-    def load(cls, path):
-        pass
-
+    def load(cls, path:str):
+        """
+        Return the binary data if saved with `as_native` otherwise return the dict
+        that contains binary graph/model on `graph` key. Check `_get_filled_dict`
+        for more details.
+        :param path: File path from where the native model or the rai models are saved
+        """
+        with open(path, 'rb') as f:
+            return f.read()

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,3 @@
 numpy
+torch
+tensorflow

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1,0 +1,87 @@
+import time
+import os
+
+from unittest import TestCase
+from redisai import model as raimodel
+from redisai import Client, Backend, Device, Tensor, DType
+import tensorflow as tf
+import torch
+
+def get_tf_graph():
+	x = tf.placeholder(tf.float32, name='input')
+	W = tf.Variable(5., name='W')
+	b = tf.Variable(3., name='b')
+	y = x * W + b
+	y = tf.identity(y, name='output')
+
+
+class MyModule(torch.jit.ScriptModule):
+    def __init__(self):
+        super(MyModule, self).__init__()
+
+    @torch.jit.script_method
+    def forward(self, a, b):
+        return a + b
+
+
+class ModelTestCase(TestCase):
+
+	def get_client(self):
+		return Client()
+
+	def testTFGraph(self):
+		y = get_tf_graph()
+		init = tf.global_variables_initializer()
+		sess = tf.Session()
+		sess.run(init)
+		path = f'{time.time()}.pb'
+		raimodel.Model.save(sess, path, output=['output'])
+		model = raimodel.Model.load(path)
+		os.remove(path)
+		con = self.get_client()
+		con.modelset(
+			'tfmodel', Backend.tf, Device.cpu, model,
+			input=['input'], output=['output'])
+		con.tensorset('a', Tensor.scalar(DType.float, 2))
+		con.modelrun('tfmodel', ['a'], 'c')
+		tensor = con.tensorget('c')
+		self.assertEqual([13], tensor.value)
+
+	def testPyTorchGraph(self):
+		torch_graph = MyModule()
+		path = f'{time.time()}.pb'
+		raimodel.Model.save(torch_graph, path)
+		model = raimodel.Model.load(path)
+		os.remove(path)
+		con = self.get_client()
+		con.modelset('ptmodel', Backend.torch, Device.cpu, model)
+		con.tensorset('a', Tensor.scalar(DType.float, 2, 5))
+		con.tensorset('b', Tensor.scalar(DType.float, 3, 7))
+		con.modelrun('ptmodel', ['a', 'b'], 'c')
+		tensor = con.tensorget('c')
+		self.assertEqual([5, 12], tensor.value)
+
+	def testFakeObjSave(self):
+		fakemodel = {}
+		self.assertRaises(
+			TypeError,
+			raimodel.Model.save, fakemodel, 'fake.pt')
+		wrongmodel_pt = torch.nn.Linear(2, 3)
+		self.assertRaises(
+			TypeError,
+			raimodel.Model.save, wrongmodel_pt, 'wrong.pt')
+
+	def testScriptLoad(self):
+		con = self.get_client()
+		dirname = os.path.dirname(__file__)
+		path = f'{dirname}/testdata/script.txt'
+		script = raimodel.Model.load(path)
+		con.scriptset('script', Device.cpu, script)
+		con.tensorset('a', Tensor.scalar(DType.float, 2, 5))
+		con.tensorset('b', Tensor.scalar(DType.float, 3, 7))
+		con.scriptrun('script', 'bar', ['a', 'b'], 'c')
+		tensor = con.tensorget('c')
+		self.assertEqual([5, 12], tensor.value)
+
+	def testPyTorchDevice(self):
+		pass

--- a/test/testdata/script.txt
+++ b/test/testdata/script.txt
@@ -1,0 +1,2 @@
+def bar(a, b):
+    return a + b


### PR DESCRIPTION
Model `save` and `load` for both TF and PyTorch backend. Next iterative PR will make the `Model` class stores all the information require to pass to modelset, like the `Tensor` class. Tests might fail because of the size of torch package that comes with default `pip`.

**EDIT**
Name of the class should be changed since it's not just for handling models (although that's the main purpose) but can be used for loading scripts as well. Will be changed in the upcoming PR

Addresses #4 