### PR TITLE
Fix DAGRUN with no LOAD or PERSIST

### DIFF
--- a/redisai/client.py
+++ b/redisai/client.py
@@ -632,7 +632,7 @@ class Dag:
                 self.commands += ["PERSIST", 1, persist, '|>']
             else:
                 self.commands += ["PERSIST", len(persist), *persist, '|>']
-        elif load:
+        else:
             self.commands.append('|>')
         self.executor = executor
 

--- a/test/test.py
+++ b/test/test.py
@@ -334,8 +334,9 @@ class DagTestCase(RedisAITestBase):
     def test_dagrun_with_persist(self):
         con = self.get_client()
 
-        dag = con.dag(persist='wrongkey')  # this won't raise Error
-        dag.tensorset('a', [2, 3, 2, 3], shape=(2, 2), dtype='float').run()
+        with self.assertRaises(ResponseError):
+            dag = con.dag(persist='wrongkey')
+            dag.tensorset('a', [2, 3, 2, 3], shape=(2, 2), dtype='float').run()
 
         dag = con.dag(persist=['b'])
         dag.tensorset('a', [2, 3, 2, 3], shape=(2, 2), dtype='float')


### PR DESCRIPTION
The most recent `AI.DAGRUN` implementation has become less tolerant with respect to syntax. Specifically, it now returns an error if the command separator `|>` is not specified after `AI.DAGRUN` when no `LOAD` or `PERSIST` are specified.

This PR makes sure the separator is always added. It also wraps a test that was supposed to fail but up until #449 it wasn't failing.