### PR TITLE
[ON HOLD] Python 3.10 support, trove, and ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ commands:
       - run:
           name: install tox dependencies
           command: |
+            pip install --upgrade pip  # numpy build issue on python 3.10
             pip install --user --quiet -r .circleci/circle_requirements.txt
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ commands:
       - run:
           name: install tox dependencies
           command: |
-            pip install --user --upgrade pip  # numpy build issue on python 3.10
+            sudo pip install --upgrade pip  # numpy build issue on python 3.10
             pip install --user --quiet -r .circleci/circle_requirements.txt
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ commands:
       - run:
           name: install tox dependencies
           command: |
-            pip install --upgrade pip  # numpy build issue on python 3.10
+            pip install --user --upgrade pip  # numpy build issue on python 3.10
             pip install --user --quiet -r .circleci/circle_requirements.txt
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,8 @@ commands:
       - run:
           name: build sdist and wheels
           command: |
+            # https://github.com/python-poetry/poetry/issues/4210
+            poetry config experimental.new-installer false
             poetry build
 
       - run:
@@ -122,7 +124,8 @@ python-versions: &python-versions
         - "3.7.9"
         - "3.8.9"
         - "3.9.4"
-          # - "latest"  # numpy wheel does not build in python 3.10. disabling for now.
+        - "3.10.0"
+        - "latest"
 
 workflows:
   version: 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
     'License :: OSI Approved :: BSD License',
     'Development Status :: 5 - Production/Stable'
 ]


### PR DESCRIPTION
Due to the numpy trove issue, we can't yet have this pass on 3.10