### PR TITLE
update type-hinting for parameters

### DIFF
--- a/redisai/client.py
+++ b/redisai/client.py
@@ -646,7 +646,7 @@ class Client(StrictRedis):
         res = self.execute_command(*args)
         return res if not self.enable_postprocess else processor.scriptset(res)
 
-    def scriptget(self, key: AnyStr, meta_only: Optional[bool] = False) -> dict:
+    def scriptget(self, key: AnyStr, meta_only: bool = False) -> dict:
         """
         Get the saved script from RedisAI. Operation similar to model get
 

--- a/redisai/client.py
+++ b/redisai/client.py
@@ -1,6 +1,6 @@
 import warnings
 from functools import wraps
-from typing import AnyStr, ByteString, List, Sequence, Union
+from typing import AnyStr, ByteString, List, Optional, Sequence, Union
 
 import numpy as np
 from deprecated import deprecated
@@ -47,7 +47,7 @@ class Client(StrictRedis):
             self.execute_command = enable_debug(super().execute_command)
         self.enable_postprocess = enable_postprocess
 
-    def pipeline(self, transaction: bool = True, shard_hint: bool = None) -> "Pipeline":
+    def pipeline(self, transaction: bool = True, shard_hint: Optional[bool] = None) -> "Pipeline":
         """
         It follows the same pipeline implementation of native redis client but enables it
         to access redisai operation as well. This function is experimental in the
@@ -71,10 +71,10 @@ class Client(StrictRedis):
 
     def dag(
         self,
-        load: Sequence = None,
-        persist: Sequence = None,
-        routing: AnyStr = None,
-        timeout: int = None,
+        load: Optional[Sequence] = None,
+        persist: Optional[Sequence] = None,
+        routing: Optional[AnyStr] = None,
+        timeout: Optional[int] = None,
         readonly: bool = False
     ) -> "Dag":
         """
@@ -154,12 +154,12 @@ class Client(StrictRedis):
         backend: str,
         device: str,
         data: ByteString,
-        batch: int = None,
-        minbatch: int = None,
-        minbatchtimeout: int = None,
-        tag: AnyStr = None,
-        inputs: Union[AnyStr, List[AnyStr]] = None,
-        outputs: Union[AnyStr, List[AnyStr]] = None,
+        batch: Optional[int] = None,
+        minbatch: Optional[int] = None,
+        minbatchtimeout: Optional[int] = None,
+        tag: Optional[AnyStr] = None,
+        inputs: Optional[Union[AnyStr, List[AnyStr]]] = None,
+        outputs: Optional[Union[AnyStr, List[AnyStr]]] = None,
     ) -> str:
         """
         Set the model on provided key.
@@ -231,11 +231,11 @@ class Client(StrictRedis):
         backend: str,
         device: str,
         data: ByteString,
-        batch: int = None,
-        minbatch: int = None,
-        tag: AnyStr = None,
-        inputs: Union[AnyStr, List[AnyStr]] = None,
-        outputs: Union[AnyStr, List[AnyStr]] = None,
+        batch: Optional[int] = None,
+        minbatch: Optional[int] = None,
+        tag: Optional[AnyStr] = None,
+        inputs: Optional[Union[AnyStr, List[AnyStr]]] = None,
+        outputs: Optional[Union[AnyStr, List[AnyStr]]] = None,
     ) -> str:
         """
         Set the model on provided key.
@@ -287,7 +287,7 @@ class Client(StrictRedis):
         res = self.execute_command(*args)
         return res if not self.enable_postprocess else processor.modelset(res)
 
-    def modelget(self, key: AnyStr, meta_only=False) -> dict:
+    def modelget(self, key: AnyStr, meta_only: Optional[bool] = False) -> dict:
         """
         Fetch the model details and the model blob back from RedisAI
 
@@ -341,7 +341,7 @@ class Client(StrictRedis):
         key: AnyStr,
         inputs: Union[AnyStr, List[AnyStr]],
         outputs: Union[AnyStr, List[AnyStr]],
-        timeout: int = None,
+        timeout: Optional[int] = None,
     ) -> str:
         """
         Run the model using input(s) which are already in the scope and are associated
@@ -459,8 +459,8 @@ class Client(StrictRedis):
         self,
         key: AnyStr,
         tensor: Union[np.ndarray, list, tuple],
-        shape: Sequence[int] = None,
-        dtype: str = None,
+        shape: Optional[Sequence[int]] = None,
+        dtype: Optional[str] = None,
     ) -> str:
         """
         Set the tensor to a key in RedisAI
@@ -541,7 +541,7 @@ class Client(StrictRedis):
         )
 
     def scriptstore(
-        self, key: AnyStr, device: str, script: str, entry_points: Union[str, Sequence[str]], tag: AnyStr = None
+        self, key: AnyStr, device: str, script: str, entry_points: Union[str, Sequence[str]], tag: Optional[AnyStr] = None
     ) -> str:
         """
         Set the script to RedisAI. The difference from scriptset is that in scriptstore
@@ -601,7 +601,7 @@ class Client(StrictRedis):
 
     @deprecated(version="1.2.0", reason="Use scriptstore instead")
     def scriptset(
-        self, key: AnyStr, device: str, script: str, tag: AnyStr = None
+        self, key: AnyStr, device: str, script: str, tag: Optional[AnyStr] = None
     ) -> str:
         """
         Set the script to RedisAI. Action similar to Modelset. RedisAI uses the TorchScript
@@ -646,7 +646,7 @@ class Client(StrictRedis):
         res = self.execute_command(*args)
         return res if not self.enable_postprocess else processor.scriptset(res)
 
-    def scriptget(self, key: AnyStr, meta_only=False) -> dict:
+    def scriptget(self, key: AnyStr, meta_only: Optional[bool] = False) -> dict:
         """
         Get the saved script from RedisAI. Operation similar to model get
 
@@ -736,11 +736,11 @@ class Client(StrictRedis):
         self,
         key: AnyStr,
         function: str,
-        keys: Union[AnyStr, Sequence[AnyStr]] = None,
-        inputs: Union[AnyStr, Sequence[AnyStr]] = None,
-        args: Union[AnyStr, Sequence[AnyStr]] = None,
-        outputs: Union[AnyStr, Sequence[AnyStr]] = None,
-        timeout: int = None,
+        keys: Optional[Union[AnyStr, Sequence[AnyStr]]] = None,
+        inputs: Optional[Union[AnyStr, Sequence[AnyStr]]] = None,
+        args: Optional[Union[AnyStr, Sequence[AnyStr]]] = None,
+        outputs: Optional[Union[AnyStr, Sequence[AnyStr]]] = None,
+        timeout: Optional[int] = None,
     ) -> str:
         """
         Run an already set script. Similar to modelexecute.

--- a/redisai/client.py
+++ b/redisai/client.py
@@ -1,6 +1,7 @@
 import warnings
 from functools import wraps
-from typing import AnyStr, ByteString, List, Optional, Sequence, Union
+from typing import (Any, AnyStr, ByteString, Dict, List, Optional, Sequence,
+                    Union, overload)
 
 import numpy as np
 from deprecated import deprecated
@@ -493,13 +494,29 @@ class Client(StrictRedis):
         res = self.execute_command(*args)
         return res if not self.enable_postprocess else processor.tensorset(res)
 
+    @overload
+    def tensorget(self, key: AnyStr, as_numpy: bool = True, as_numpy_mutable: bool = False, meta_only: bool = False) -> np.ndarray:
+        ...
+
+    @overload
+    def tensorget(self, key: AnyStr, as_numpy: bool = False, as_numpy_mutable: bool = True, meta_only: bool = False) -> np.ndarray:
+        ...
+
+    @overload
+    def tensorget(self, key: AnyStr, as_numpy: bool = False, as_numpy_mutable: bool = False, meta_only: bool = True) -> Dict[str, Any]:
+        ...
+
+    @overload
+    def tensorget(self, key: AnyStr, as_numpy: bool = False, as_numpy_mutable: bool = False, meta_only: bool = False) -> List[Any]:
+        ...
+
     def tensorget(
         self,
         key: AnyStr,
         as_numpy: bool = True,
         as_numpy_mutable: bool = False,
         meta_only: bool = False,
-    ) -> Union[dict, np.ndarray]:
+    ) -> Any:
         """
         Retrieve the value of a tensor from the server. By default it returns the numpy
         array but it can be controlled using the `as_type` and `meta_only` argument.

--- a/redisai/client.py
+++ b/redisai/client.py
@@ -288,7 +288,7 @@ class Client(StrictRedis):
         res = self.execute_command(*args)
         return res if not self.enable_postprocess else processor.modelset(res)
 
-    def modelget(self, key: AnyStr, meta_only: Optional[bool] = False) -> dict:
+    def modelget(self, key: AnyStr, meta_only: Optional[bool] = False) -> Dict[str, str]:
         """
         Fetch the model details and the model blob back from RedisAI
 

--- a/redisai/dag.py
+++ b/redisai/dag.py
@@ -1,6 +1,6 @@
 import warnings
 from functools import partial
-from typing import Any, AnyStr, List, Optional, Sequence, Union
+from typing import AnyStr, List, Optional, Sequence, Union
 
 import numpy as np
 from deprecated import deprecated

--- a/redisai/dag.py
+++ b/redisai/dag.py
@@ -63,7 +63,7 @@ class Dag:
         tensor: Union[np.ndarray, list, tuple],
         shape: Optional[Sequence[int]] = None,
         dtype: Optional[str] = None,
-    ) -> Any:
+    ) -> "Dag":
         args = builder.tensorset(key, tensor, shape, dtype)
         self.commands.extend(args)
         self.commands.append("|>")
@@ -76,7 +76,7 @@ class Dag:
         as_numpy: bool = True,
         as_numpy_mutable: bool = False,
         meta_only: bool = False,
-    ) -> Any:
+    ) -> "Dag":
         args = builder.tensorget(key, as_numpy, as_numpy_mutable)
         self.commands.extend(args)
         self.commands.append("|>")
@@ -96,7 +96,7 @@ class Dag:
             key: AnyStr,
             inputs: Union[AnyStr, List[AnyStr]],
             outputs: Union[AnyStr, List[AnyStr]],
-    ) -> Any:
+    ) -> "Dag":
         if self.deprecatedDagrunMode:
             args = builder.modelrun(key, inputs, outputs)
             self.commands.extend(args)
@@ -111,7 +111,7 @@ class Dag:
         key: AnyStr,
         inputs: Union[AnyStr, List[AnyStr]],
         outputs: Union[AnyStr, List[AnyStr]],
-    ) -> Any:
+    ) -> "Dag":
         if self.deprecatedDagrunMode:
             raise RuntimeError(
                 "You are using deprecated version of DAG, that does not supports MODELEXECUTE."
@@ -132,7 +132,7 @@ class Dag:
         inputs: Optional[Union[AnyStr, Sequence[AnyStr]]] = None,
         args: Optional[Union[AnyStr, Sequence[AnyStr]]] = None,
         outputs: Optional[Union[AnyStr, List[AnyStr]]] = None,
-    ) -> Any:
+    ) -> "Dag":
         if self.readonly:
             raise RuntimeError(
                 "AI.SCRIPTEXECUTE cannot be used in readonly mode"
@@ -150,10 +150,10 @@ class Dag:
         return self
 
     @deprecated(version="1.2.0", reason="Use execute instead")
-    def run(self):
+    def run(self) -> List[str]:
         return self.execute()
 
-    def execute(self):
+    def execute(self) -> List[str]:
         commands = self.commands[:-1]  # removing the last "|>"
         results = self.executor(*commands)
         if self.enable_postprocess:

--- a/redisai/dag.py
+++ b/redisai/dag.py
@@ -1,12 +1,12 @@
+import warnings
 from functools import partial
-from typing import Any, AnyStr, List, Sequence, Union
+from typing import Any, AnyStr, List, Optional, Sequence, Union
 
 import numpy as np
+from deprecated import deprecated
 
 from redisai import command_builder as builder
 from redisai.postprocessor import Processor
-from deprecated import deprecated
-import warnings
 
 processor = Processor()
 
@@ -61,8 +61,8 @@ class Dag:
         self,
         key: AnyStr,
         tensor: Union[np.ndarray, list, tuple],
-        shape: Sequence[int] = None,
-        dtype: str = None,
+        shape: Optional[Sequence[int]] = None,
+        dtype: Optional[str] = None,
     ) -> Any:
         args = builder.tensorset(key, tensor, shape, dtype)
         self.commands.extend(args)
@@ -128,10 +128,10 @@ class Dag:
         self,
         key: AnyStr,
         function: str,
-        keys: Union[AnyStr, Sequence[AnyStr]] = None,
-        inputs: Union[AnyStr, Sequence[AnyStr]] = None,
-        args: Union[AnyStr, Sequence[AnyStr]] = None,
-        outputs: Union[AnyStr, List[AnyStr]] = None,
+        keys: Optional[Union[AnyStr, Sequence[AnyStr]]] = None,
+        inputs: Optional[Union[AnyStr, Sequence[AnyStr]]] = None,
+        args: Optional[Union[AnyStr, Sequence[AnyStr]]] = None,
+        outputs: Optional[Union[AnyStr, List[AnyStr]]] = None,
     ) -> Any:
         if self.readonly:
             raise RuntimeError(

--- a/redisai/pipeline.py
+++ b/redisai/pipeline.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import AnyStr, Sequence, Union
+from typing import AnyStr, Optional, Sequence, Union
 
 import numpy as np
 import redis
@@ -33,8 +33,8 @@ class Pipeline(redis.client.Pipeline):
         self,
         key: AnyStr,
         tensor: Union[np.ndarray, list, tuple],
-        shape: Sequence[int] = None,
-        dtype: str = None,
+        shape: Optional[Sequence[int]] = None,
+        dtype: Optional[str] = None,
     ) -> str:
         args = builder.tensorset(key, tensor, shape, dtype)
         return self.execute_command(*args)

--- a/redisai/postprocessor.py
+++ b/redisai/postprocessor.py
@@ -5,7 +5,7 @@ import numpy as np
 from . import utils
 
 
-def decoder(val):
+def _decoder(val):
     return val.decode()
 
 
@@ -13,33 +13,13 @@ class Processor:
     @staticmethod
     def modelget(res):
         resdict = utils.list2dict(res)
-        utils.recursive_bytetransform(resdict["inputs"], lambda x: x.decode())
-        utils.recursive_bytetransform(resdict["outputs"], lambda x: x.decode())
+        utils.recursive_bytetransform(resdict["inputs"], _decoder)
+        utils.recursive_bytetransform(resdict["outputs"], _decoder)
         return resdict
 
     @staticmethod
     def modelscan(res):
-        return utils.recursive_bytetransform(res, lambda x: x.decode())
-
-    @overload
-    @staticmethod
-    def tensorget(res: List[Any], as_numpy: bool = True, as_numpy_mutable: bool = False, meta_only: bool = False) -> np.ndarray:
-        ...
-
-    @overload
-    @staticmethod
-    def tensorget(res: List[Any], as_numpy: bool = False, as_numpy_mutable: bool = True, meta_only: bool = False) -> np.ndarray:
-        ...
-
-    @overload
-    @staticmethod
-    def tensorget(res: List[Any], as_numpy: bool = False, as_numpy_mutable: bool = False, meta_only: bool = True) -> Dict[str, Any]:
-        ...
-
-    @overload
-    @staticmethod
-    def tensorget(res: List[Any]) -> List[Any]:
-        ...
+        return utils.recursive_bytetransform(res, _decoder)
 
     @staticmethod
     def tensorget(res: List[Any], as_numpy: bool = False, as_numpy_mutable: bool = False, meta_only: bool = False) -> Any:
@@ -69,8 +49,7 @@ class Processor:
             )
         else:
             if rai_result["dtype"] == "STRING":
-                def target(b):
-                    return b.decode()
+                target = _decoder
             else:
                 target = float if rai_result["dtype"] in ("FLOAT", "DOUBLE") else int
             utils.recursive_bytetransform(rai_result["values"], target)
@@ -82,7 +61,7 @@ class Processor:
 
     @staticmethod
     def scriptscan(res):
-        return utils.recursive_bytetransform(res, lambda x: x.decode())
+        return utils.recursive_bytetransform(res, _decoder)
 
     @staticmethod
     def infoget(res):
@@ -90,7 +69,7 @@ class Processor:
 
 
 # These functions are only doing decoding on the output from redis
-decoder = staticmethod(decoder)
+decoder = staticmethod(_decoder)
 decoding_functions = (
     "loadbackend",
     "modelstore",

--- a/redisai/postprocessor.py
+++ b/redisai/postprocessor.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from . import utils
 
 
@@ -18,7 +20,7 @@ class Processor:
         return utils.recursive_bytetransform(res, lambda x: x.decode())
 
     @staticmethod
-    def tensorget(res, as_numpy, as_numpy_mutable, meta_only):
+    def tensorget(res: Any, as_numpy: bool, as_numpy_mutable: bool, meta_only: bool):
         """Process the tensorget output.
 
         If ``as_numpy`` is True, it'll be converted to a numpy array. The required

--- a/redisai/postprocessor.py
+++ b/redisai/postprocessor.py
@@ -1,7 +1,5 @@
 from typing import Any, List
 
-import numpy as np
-
 from . import utils
 
 

--- a/redisai/postprocessor.py
+++ b/redisai/postprocessor.py
@@ -1,4 +1,6 @@
-from typing import Any
+from typing import Any, Dict, List, Union, overload
+
+import numpy as np
 
 from . import utils
 
@@ -19,13 +21,35 @@ class Processor:
     def modelscan(res):
         return utils.recursive_bytetransform(res, lambda x: x.decode())
 
+    @overload
     @staticmethod
-    def tensorget(res: Any, as_numpy: bool, as_numpy_mutable: bool, meta_only: bool):
+    def tensorget(res: List[Any], as_numpy: bool = True, as_numpy_mutable: bool = False, meta_only: bool = False) -> np.ndarray:
+        ...
+
+    @overload
+    @staticmethod
+    def tensorget(res: List[Any], as_numpy: bool = False, as_numpy_mutable: bool = True, meta_only: bool = False) -> np.ndarray:
+        ...
+
+    @overload
+    @staticmethod
+    def tensorget(res: List[Any], as_numpy: bool = False, as_numpy_mutable: bool = False, meta_only: bool = True) -> Dict[str, Any]:
+        ...
+
+    @overload
+    @staticmethod
+    def tensorget(res: List[Any]) -> List[Any]:
+        ...
+
+    @staticmethod
+    def tensorget(res: List[Any], as_numpy: bool = False, as_numpy_mutable: bool = False, meta_only: bool = False) -> Any:
         """Process the tensorget output.
 
         If ``as_numpy`` is True, it'll be converted to a numpy array. The required
         information such as datatype and shape must be in ``rai_result`` itself.
         """
+        if (as_numpy and as_numpy_mutable) or (as_numpy and meta_only) or (as_numpy_mutable and meta_only):
+            raise Exception("Only one parameter should be set to true")
         rai_result = utils.list2dict(res)
         if meta_only is True:
             return rai_result

--- a/redisai/postprocessor.py
+++ b/redisai/postprocessor.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, overload
+from typing import Any, List
 
 import numpy as np
 

--- a/redisai/postprocessor.py
+++ b/redisai/postprocessor.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Union, overload
+from typing import Any, Dict, List, overload
 
 import numpy as np
 

--- a/redisai/utils.py
+++ b/redisai/utils.py
@@ -1,5 +1,8 @@
-from typing import AnyStr, ByteString, Callable, List, Sequence, Union
+from typing import AnyStr, ByteString, Callable, List, Sequence, TypeVar, Union
+
 import numpy as np
+
+ReturnType = TypeVar("ReturnType")
 
 dtype_dict = {
     "float": "FLOAT",
@@ -66,7 +69,7 @@ def list2dict(lst):
     return out
 
 
-def recursive_bytetransform(arr: List[AnyStr], target: Callable) -> list:
+def recursive_bytetransform(arr: List[AnyStr], target: Callable[..., ReturnType]) -> list[ReturnType]:
     """
     Recurse value, replacing each element of b'' with the appropriate element.
 


### PR DESCRIPTION
There are a lot of places where the typing is not proper, ie `param: int = None` instead of `param: Optional[int] = None`. This difference causes type checkers to complain user side when providing `None` directly or not providing any param to recieve the default `None`. I only fixed for user facing functions to be minimal.